### PR TITLE
Set Jupyter env. image version

### DIFF
--- a/book/appendix/notebooks/A1_systematic_uncertainties.ipynb
+++ b/book/appendix/notebooks/A1_systematic_uncertainties.ipynb
@@ -64,7 +64,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mg_dir = \"/madminer/software/MG5_amC_v2_6_7/\""
+    "mg_dir = \"/madminer/software/MG5_amC_v2_9_4/\""
    ]
   },
   {

--- a/book/tutorial/2_preliminaries.md
+++ b/book/tutorial/2_preliminaries.md
@@ -47,7 +47,7 @@ The first time we spin it up, the image needs to be pulled from DockerHub, which
 docker run --rm \
     -p 8888:8888 \
     -v ~/madminer_shared:/home/shared \
-    -it madminertool/madminer-jupyter-env \
+    -it madminertool/madminer-jupyter-env:0.3.0 \
     /bin/bash
 ```
 
@@ -95,18 +95,6 @@ paste the token you just copied and log in. Then you will be all set, and will s
 ![Jupyter login page][jupyter-login-image]
 
 
-## Update the Docker image
-While developing and testing this tutorial we may occasionally update the Docker image.
-If you completed the preliminaries some time ago, you might want to get the most updated image by doing:
-
-```bash
-docker pull madminertool/madminer-jupyter-env
-```
-
-This will replace all the internal contents of the Docker image, but not the files in the shared directory.
-You will still want to re-do the steps described above in the **Start Jupyter server in a container** section.
-
-
 ## Special instructions: Docker Toolbox for Windows
 Thanks to Ioannis Karkanias, there is a way to run the Jupyter server using Docker Toolbox
 
@@ -118,7 +106,7 @@ Thanks to Ioannis Karkanias, there is a way to run the Jupyter server using Dock
     docker run --rm \
         -p 8888:8888 \
         -v /C/Users/<USERNAME>/madminer_shared:/home/shared \
-        -it madminertool/madminer-jupyter-env \
+        -it madminertool/madminer-jupyter-env:0.3.0 \
         /bin/bash
     ```
 

--- a/book/tutorial/5_data_generation.md
+++ b/book/tutorial/5_data_generation.md
@@ -19,7 +19,7 @@ In tutorial sections:
 The location of the MadGraph installation folder is set. It is listed as:
 
 ```python
-mg_dir = '/madminer/software/MG5_aMC_v2_6_7'
+mg_dir = '/madminer/software/MG5_aMC_v2_9_4'
 ```
 
 If you install everything yourself, then you would also need to change this to point

--- a/book/tutorial/notebooks/general/2a_parton_analysis.ipynb
+++ b/book/tutorial/notebooks/general/2a_parton_analysis.ipynb
@@ -80,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mg_dir = '/madminer/software/MG5_aMC_v2_6_7'"
+    "mg_dir = '/madminer/software/MG5_aMC_v2_9_4'"
    ]
   },
   {

--- a/book/tutorial/notebooks/general/2b_delphes_analysis.ipynb
+++ b/book/tutorial/notebooks/general/2b_delphes_analysis.ipynb
@@ -80,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mg_dir = '/madminer/software/MG5_amC_v2_6_7/'"
+    "mg_dir = '/madminer/software/MG5_amC_v2_9_4/'"
    ]
   },
   {

--- a/book/tutorial/notebooks/general/4c_information_geometry.ipynb
+++ b/book/tutorial/notebooks/general/4c_information_geometry.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "import sys\n",
     "import os\n",
-    "madminer_src_path = \"/madminer/software/MG5_aMC_v2_6_7/\"\n",
+    "madminer_src_path = \"/madminer/software/MG5_aMC_v2_9_4/\"\n",
     "sys.path.append(madminer_src_path)\n",
     "\n",
     "import logging\n",


### PR DESCRIPTION
This PR sets a specific version (`v0.3.0`) of the [madminer-jupyter-env](https://hub.docker.com/r/madminertool/madminer-jupyter-env) Docker image to be used throughout the tutorial.

It is important to change the Docker image references to an **explicit** version as it will be easier to control the environment people are running the tutorial into. Otherwise, the `latest` version would be used, but `latest` will inadvertently change at some point in time.

Finally, all references to the old Docker image MadGraph installation (`2.6.7`) have been updated to the new one (`2.9.4`).