### PR TITLE
Add deployment docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,3 @@ build:
 clean:
 	@echo "Removing Jupyter book outputs..."
 	@jupyter-book clean --all $(BOOK_OUTPUT_FOLDER)
-
-
-.PHONY: push
-push: build
-	@echo "Updating published Jupyter book..."
-	@ghp-import --no-jekyll --push --force "_build/html"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ make build
 ```
 
 
+## Deploying the site
+The deployment is carry out **automatically** by a [GitHub Actions workflow][madminer-tutorial-workflow-web].
+
+
+The tutorial will be deployed when any change is detected to the `book` directory, within the main repository branch.
+The deployment workflow uses the popular [GH pages][github-pages-action] action in order to push a built version
+of the tutorial into the [gh-pages][madminer-tutorial-branch-pages] branch.
+
+
+[github-pages-action]: https://github.com/marketplace/actions/github-pages-action
 [madminer-tutorial-web]: https://madminer-tool.github.io/madminer-tutorial
 [madminer-tutorial-binder-link]: https://mybinder.org/v2/gh/cranmer/madminer-tutorial/master
 [madminer-tutorial-binder-logo]: https://mybinder.org/badge_logo.svg
+[madminer-tutorial-branch-pages]: https://github.com/madminer-tool/madminer-tutorial/tree/gh-pages
+[madminer-tutorial-workflow-web]: https://github.com/madminer-tool/madminer-tutorial/blob/master/.github/workflows/web.yml

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ of the tutorial into the [gh-pages][madminer-tutorial-branch-pages] branch.
 
 [github-pages-action]: https://github.com/marketplace/actions/github-pages-action
 [madminer-tutorial-web]: https://madminer-tool.github.io/madminer-tutorial
-[madminer-tutorial-binder-link]: https://mybinder.org/v2/gh/cranmer/madminer-tutorial/master
+[madminer-tutorial-binder-link]: https://mybinder.org/v2/gh/madminer-tool/madminer-tutorial/master
 [madminer-tutorial-binder-logo]: https://mybinder.org/badge_logo.svg
 [madminer-tutorial-branch-pages]: https://github.com/madminer-tool/madminer-tutorial/tree/gh-pages
 [madminer-tutorial-workflow-web]: https://github.com/madminer-tool/madminer-tutorial/blob/master/.github/workflows/web.yml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-ghp-import==1.1.0
 jupyter-book==0.10.2


### PR DESCRIPTION
This PR adds documentation on how the tutorial is **automagically** ✨  deployed to _github-pages_. (available at [this URL](https://madminer-tool.github.io/madminer-tutorial/tutorial/0_intro.html)).

It also removes an unused **manual** way of deploying updates to the web (via [Makefile](https://github.com/madminer-tool/madminer-tutorial/blob/master/Makefile) rules).