### PR TITLE
Appendix & REANA sections typos

### DIFF
--- a/book/appendix/notebooks/A1_systematic_uncertainties.ipynb
+++ b/book/appendix/notebooks/A1_systematic_uncertainties.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this tutorial we'll explain how to add systematic uncertainties to the MadMiner workflow. Note that the treatment of systematic uncertainties changed substantially with `MadMiner v0.6`, including changes to the MadMiner file specification. Please don't use files from older MadMiner versions with systematic uncertainties."
+    "In this tutorial we'll explain how to add systematic uncertainties to the MadMiner workflow."
    ]
   },
   {
@@ -27,7 +27,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before you execute this notebook, make sure you have running installations of MadGraph, Pythia, and Delphes."
+    "Before you execute this notebook, make sure you have MadGraph, Pythia and Delphes installed."
    ]
   },
   {

--- a/book/appendix/notebooks/A2_ensemble_methods.ipynb
+++ b/book/appendix/notebooks/A2_ensemble_methods.ipynb
@@ -13,13 +13,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## (UNDER CONSTRUCTION)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Instead of using a single neural network to estimate the likelihood ratio, score, or Fisher information, we can use an ensemble of such estimators. That provides us with a more reliable mean prediction as well as a measure of the uncertainty. The class `madminer.ml.EnsembleForge` automates this process. Currently, it only supports SALLY estimators:"
    ]
   },

--- a/book/reana/3_parametrization.md
+++ b/book/reana/3_parametrization.md
@@ -20,7 +20,7 @@ please, visit the [MadMiner documentation][madminer-docs].
 When running locally, via Yadage, there is a small set of parameters being defined at the `Makefile` level.
 These parameters can be found within the `yadage-run` Makefile rule, and they affect either one of the sub-workflows:
 
-In the case of the **PH sub-workflow**:
+In the case of the **Physics sub-workflow**:
 - `input_file`: path to the input.yml file to use.
 - `num_procs_per_job`: number of parallel processes for the collision event generation.
 
@@ -31,7 +31,7 @@ In the case of the **ML sub-workflow**:
 - `mlflow_args_t`: arguments to override the default training values.
 - `mlflow_args_e`: arguments to override the default evaluation values.
 
-In order to override the default MLFlow-specific arguments (specified on the[MLproject][madminer-workflow-mlproject] file),
+In order to override the default MLFlow-specific arguments (specified on the [MLproject][madminer-workflow-mlproject] file),
 change the `mlflow_args_` parameters. For example, to override the MLFlow parameters of the _sampling_ step:
 
 ```makefile

--- a/book/reana/4_reana_setup.md
+++ b/book/reana/4_reana_setup.md
@@ -27,9 +27,10 @@ source /afs/cern.ch/user/r/reana/public/reana/bin/activate
 ## Get access token
 You will need access to a REANA server instance. You can find your authentication **token** within the REANA instance web interface.
 There is a [REANA instance at CERN][reana-instance-cern], but it requires a CERN user account. There is also one running at BNL,
-which was used for the [demo video][tutorial-section-demo]. Alternatively, you can also contact the system administrators
-for your university or lab to ask if they can deploy a REANA instance. For instance, we have set up a REANA instance
-on the [NYU Greene][nyu-cluster-greene] cluster, which uses the SLURM backend to submit jobs.
+which was used for the [demo video][tutorial-section-demo].
+
+Alternatively, you can also contact the system administrators for your university or lab to ask if they can deploy a REANA instance.
+For instance, we have set up a REANA instance on the [NYU Greene][nyu-cluster-greene] cluster, which uses the SLURM backend to submit jobs.
 
 
 ## Configure the client


### PR DESCRIPTION
This PR fixes typos within the `Appendix` and `REANA` tutorial sections.